### PR TITLE
notifyTestFailed should take testId as input to enable parallel test …

### DIFF
--- a/org.eclipse.unittest/src/org/eclipse/unittest/model/ITestRunListener.java
+++ b/org.eclipse.unittest/src/org/eclipse/unittest/model/ITestRunListener.java
@@ -79,8 +79,7 @@ public interface ITestRunListener {
 	void testRunTerminated();
 
 	/**
-	 * Information about a member of the test suite that is about to be run. The
-	 * format of the string is:
+	 * Information about a member of the test suite that is about to be run.
 	 *
 	 * @param testId         a unique id for the test
 	 * @param testName       the name of the test


### PR DESCRIPTION
…execution #24

Fixes: #24

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>