### PR TITLE
Bug 507626: Debug framework should provide a generic "test report" vi…

### DIFF
--- a/org.eclipse.unittest.cdt/src/org/eclipse/unittest/cdt/launcher/BaseTestsLaunchDelegate.java
+++ b/org.eclipse.unittest.cdt/src/org/eclipse/unittest/cdt/launcher/BaseTestsLaunchDelegate.java
@@ -27,7 +27,6 @@ import org.eclipse.cdt.testsrunner.internal.ui.view.TestPathUtils;
 import org.eclipse.cdt.testsrunner.launcher.ITestsRunnerProvider;
 import org.eclipse.cdt.testsrunner.model.TestingException;
 import org.eclipse.unittest.cdt.internal.launcher.LauncherMessages;
-import org.eclipse.unittest.launcher.UnitTestLaunchConfigurationConstants;
 import org.eclipse.unittest.ui.ITestViewSupport;
 
 import org.eclipse.core.runtime.CoreException;
@@ -146,7 +145,7 @@ public abstract class BaseTestsLaunchDelegate extends LaunchConfigurationDelegat
 	private void updatedLaunchConfiguration(ILaunchConfiguration config) throws CoreException {
 		changesToLaunchConfiguration.clear();
 		ILaunchConfigurationWorkingCopy configWC = config.getWorkingCopy();
-		configWC.setAttribute(UnitTestLaunchConfigurationConstants.ATTR_UNIT_TEST_VIEW_SUPPORT, getUnitTestViewSupportID());
+		ITestViewSupport.configure(configWC, getUnitTestViewSupportID());
 		setProgramArguments(configWC);
 		configWC.doSave();
 	}

--- a/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/launcher/JUnitLaunchConfigurationTab.java
+++ b/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/launcher/JUnitLaunchConfigurationTab.java
@@ -29,7 +29,7 @@ import org.eclipse.unittest.junit.launcher.util.JUnitStubUtility;
 import org.eclipse.unittest.junit.launcher.util.LayoutUtil;
 import org.eclipse.unittest.junit.ui.BasicElementLabels;
 import org.eclipse.unittest.junit.ui.JUnitMessages;
-import org.eclipse.unittest.launcher.UnitTestLaunchConfigurationConstants;
+import org.eclipse.unittest.ui.ITestViewSupport;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -559,8 +559,7 @@ public class JUnitLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
 			config.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_CONTAINER, ""); //$NON-NLS-1$
 			config.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_NAME, fTestMethodText.getText());
 		}
-		config.setAttribute(UnitTestLaunchConfigurationConstants.ATTR_UNIT_TEST_VIEW_SUPPORT,
-				JUnitTestPlugin.UNIT_TEST_VIEW_SUPPORT_ID);
+		ITestViewSupport.configure(config, JUnitTestPlugin.UNIT_TEST_VIEW_SUPPORT_ID);
 		config.setAttribute(JUnitLaunchConfigurationConstants.ATTR_KEEPRUNNING, fKeepRunning.getSelection());
 		try {
 			mapResources(config);
@@ -1141,8 +1140,7 @@ public class JUnitLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
 		} catch (InterruptedException | InvocationTargetException ie) {
 		}
 		config.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, name);
-		if (testKindId != null)
-			config.setAttribute(UnitTestLaunchConfigurationConstants.ATTR_UNIT_TEST_VIEW_SUPPORT, testKindId);
+		ITestViewSupport.configure(config, testKindId);
 		initializeName(config, name);
 		boolean isRunWithJUnitPlatform = JUnitTestPlugin.isRunWithJUnitPlatform(javaElement);
 		if (isRunWithJUnitPlatform) {

--- a/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/launcher/JUnitLaunchShortcut.java
+++ b/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/launcher/JUnitLaunchShortcut.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
 import org.eclipse.unittest.junit.JUnitTestPlugin;
 import org.eclipse.unittest.junit.launcher.util.ExceptionHandler;
 import org.eclipse.unittest.junit.launcher.util.JUnitStubUtility;
-import org.eclipse.unittest.launcher.UnitTestLaunchConfigurationConstants;
+import org.eclipse.unittest.ui.ITestViewSupport;
 
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
@@ -399,10 +399,9 @@ public class JUnitLaunchShortcut implements ILaunchShortcut2 {
 
 		wc.setAttribute(JUnitLaunchConfigurationConstants.ATTR_KEEPRUNNING, false);
 		wc.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_CONTAINER, containerHandleId);
-		wc.setAttribute(UnitTestLaunchConfigurationConstants.ATTR_UNIT_TEST_VIEW_SUPPORT,
-				JUnitTestPlugin.UNIT_TEST_VIEW_SUPPORT_ID);
 		wc.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_RUNNER_KIND,
 				JUnitTestPlugin.getJUnitVersion(element).getJUnitTestKind().getId());
+		ITestViewSupport.configure(wc, JUnitTestPlugin.UNIT_TEST_VIEW_SUPPORT_ID);
 		JUnitMigrationDelegate.mapResources(wc);
 		AssertionVMArg.setArgDefault(wc);
 		if (testName != null) {
@@ -469,8 +468,7 @@ public class JUnitLaunchShortcut implements ILaunchShortcut2 {
 		return new String[] { IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, //
 				JUnitLaunchConfigurationConstants.ATTR_TEST_CONTAINER, //
 				IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, //
-				JUnitLaunchConfigurationConstants.ATTR_TEST_NAME, //
-				UnitTestLaunchConfigurationConstants.ATTR_UNIT_TEST_VIEW_SUPPORT };
+				JUnitLaunchConfigurationConstants.ATTR_TEST_NAME };
 	}
 
 	private static boolean hasSameAttributes(ILaunchConfiguration config1, ILaunchConfiguration config2,

--- a/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/launcher/UnitTestLaunchConfigurationConstants.java
+++ b/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/launcher/UnitTestLaunchConfigurationConstants.java
@@ -11,7 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.eclipse.unittest.launcher;
+package org.eclipse.unittest.internal.launcher;
 
 import org.eclipse.unittest.internal.UnitTestPlugin;
 import org.eclipse.unittest.ui.ITestViewSupport;

--- a/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/model/UnitTestLaunchListener.java
+++ b/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/model/UnitTestLaunchListener.java
@@ -18,7 +18,7 @@ import java.util.HashSet;
 import org.eclipse.unittest.internal.UnitTestPlugin;
 import org.eclipse.unittest.internal.launcher.TestListenerRegistry;
 import org.eclipse.unittest.internal.launcher.TestRunListener;
-import org.eclipse.unittest.launcher.UnitTestLaunchConfigurationConstants;
+import org.eclipse.unittest.internal.launcher.UnitTestLaunchConfigurationConstants;
 import org.eclipse.unittest.ui.ITestViewSupport;
 
 import org.eclipse.core.runtime.CoreException;
@@ -48,18 +48,16 @@ public class UnitTestLaunchListener implements ILaunchListener {
 			return;
 
 		try {
-			if (!config.hasAttribute(UnitTestLaunchConfigurationConstants.ATTR_UNIT_TEST_VIEW_SUPPORT)) {
+			if (!config.hasAttribute(UnitTestLaunchConfigurationConstants.ATTR_UNIT_TEST_VIEW_SUPPORT))
 				return;
-			}
 		} catch (CoreException e1) {
 			UnitTestPlugin.log(e1);
 			return;
 		}
 
 		ITestViewSupport testRunnerViewSupport = UnitTestModel.newTestRunnerViewSupport(config);
-		if (testRunnerViewSupport == null) {
+		if (testRunnerViewSupport == null)
 			return;
-		}
 
 		fTrackedLaunches.add(launch);
 	}

--- a/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/model/UnitTestModel.java
+++ b/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/model/UnitTestModel.java
@@ -30,7 +30,7 @@ import org.eclipse.unittest.internal.UnitTestPlugin;
 import org.eclipse.unittest.internal.UnitTestPreferencesConstants;
 import org.eclipse.unittest.internal.junitXmlReport.TestRunHandler;
 import org.eclipse.unittest.internal.launcher.TestViewSupportRegistry;
-import org.eclipse.unittest.launcher.UnitTestLaunchConfigurationConstants;
+import org.eclipse.unittest.internal.launcher.UnitTestLaunchConfigurationConstants;
 import org.eclipse.unittest.model.ITestRunSession;
 import org.eclipse.unittest.ui.ITestViewSupport;
 

--- a/org.eclipse.unittest.ui/src/org/eclipse/unittest/ui/ITestViewSupport.java
+++ b/org.eclipse.unittest.ui/src/org/eclipse/unittest/ui/ITestViewSupport.java
@@ -16,6 +16,7 @@ package org.eclipse.unittest.ui;
 import java.util.Collection;
 import java.util.List;
 
+import org.eclipse.unittest.internal.launcher.UnitTestLaunchConfigurationConstants;
 import org.eclipse.unittest.launcher.ITestRunnerClient;
 import org.eclipse.unittest.model.ITestCaseElement;
 import org.eclipse.unittest.model.ITestElement;
@@ -29,6 +30,7 @@ import org.eclipse.jface.action.IAction;
 import org.eclipse.ui.IViewPart;
 
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.model.ILaunchConfigurationDelegate2;
 
 /**
@@ -36,7 +38,6 @@ import org.eclipse.debug.core.model.ILaunchConfigurationDelegate2;
  * org.org.eclipse.unittest.unittestViewSupport extension.
  */
 public interface ITestViewSupport {
-
 	/**
 	 * Activates UnitTestBundle. Eclipse uses lazy bundle loading by default, which
 	 * means a bundle will not be loaded in many cases until some of its class is
@@ -52,6 +53,20 @@ public interface ITestViewSupport {
 	 */
 	static void activateBundle() {
 		// Nothing more to do
+	}
+
+	/**
+	 * Configures a Launch configuration Working Copy with an identifier of Test
+	 * View Support extension
+	 *
+	 * @param configuration              a launch configuration working copy
+	 * @param testViewSupportExtensionId a Test View Support extension identifier
+	 */
+	static void configure(ILaunchConfigurationWorkingCopy configuration, String testViewSupportExtensionId) {
+		if (configuration != null && testViewSupportExtensionId != null) {
+			configuration.setAttribute(UnitTestLaunchConfigurationConstants.ATTR_UNIT_TEST_VIEW_SUPPORT,
+					testViewSupportExtensionId);
+		}
 	}
 
 	/**


### PR DESCRIPTION
…ew - Patch set #6

A set of fixes requested for Patch Set #6 at Gerrit Review: https://git.eclipse.org/r/c/platform/eclipse.platform.debug/+/171116

Regarding the UnitTestLaunchConfigurationConstants.ATTR_UNIT_TEST_VIEW_SUPPORT:

A new API method is introduced to cofigure a Lanuch configuration Working Copy with an ID of Test View Support extension.
UnitTestLaunchConfigurationConstants class is removed

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>