### PR TITLE
Bug 507626: Debug framework should provide a generic "test report" vi…

### DIFF
--- a/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/junitXmlReport/TestRunHandler.java
+++ b/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/junitXmlReport/TestRunHandler.java
@@ -66,7 +66,7 @@ public class TestRunHandler extends DefaultHandler {
 
 	private Result fStatus;
 
-	private IProgressMonitor fMonitor;
+	private final IProgressMonitor fMonitor;
 	private int fLastReportedLine;
 
 	/**
@@ -82,7 +82,7 @@ public class TestRunHandler extends DefaultHandler {
 	 * @param monitor a progress monitor
 	 */
 	public TestRunHandler(IProgressMonitor monitor) {
-		fMonitor = monitor;
+		fMonitor = monitor != null ? monitor : new NullProgressMonitor();
 	}
 
 	@Override
@@ -97,10 +97,10 @@ public class TestRunHandler extends DefaultHandler {
 
 	@Override
 	public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-		if (fMonitor != null && fMonitor.isCanceled())
+		if (fMonitor.isCanceled())
 			throw new OperationCanceledException();
 
-		if (fLocator != null && fMonitor != null) {
+		if (fLocator != null) {
 			int line = fLocator.getLineNumber();
 			if (line - 20 >= fLastReportedLine) {
 				line -= line % 20;

--- a/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/launcher/TestViewSupportRegistry.java
+++ b/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/launcher/TestViewSupportRegistry.java
@@ -16,6 +16,7 @@ package org.eclipse.unittest.internal.launcher;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.eclipse.unittest.internal.UnitTestPlugin;
@@ -26,6 +27,8 @@ import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
 import org.eclipse.core.runtime.IExtensionPoint;
 import org.eclipse.core.runtime.Platform;
+
+import org.eclipse.debug.core.ILaunchConfiguration;
 
 /**
  * Test View Support registry
@@ -96,15 +99,15 @@ public class TestViewSupportRegistry {
 		fTestViewSupportExtensions = items;
 	}
 
-	/**
+	/*
 	 * Returns an {@link ITestViewSupport} object instance by its identifier
 	 *
 	 * @param id an identifier, can be <code>null</code>
 	 *
 	 * @return an {@link ITestViewSupport} object instance, or <code>null</code> if
-	 *         not available
+	 * not available
 	 */
-	public ITestViewSupport getTestViewSupportInstance(String id) {
+	private Optional<ITestViewSupport> findTestViewSupport(String id) {
 		return getAllTestViewSupportExtensions().stream().filter(ext -> ext.getId().equals(id)).findFirst().map(t -> {
 			try {
 				return t.instantiateTestViewSupport();
@@ -112,7 +115,24 @@ public class TestViewSupportRegistry {
 				UnitTestPlugin.log(e);
 				return null;
 			}
-		}).orElse(null);
+		});
+	}
+
+	/**
+	 * Returns {@link ITestViewSupport} instance from the given launch configuration
+	 *
+	 * @param launchConfiguration a launch configuration
+	 * @return a test runner view support instance if exists or <code>null</code>.
+	 */
+	public static ITestViewSupport newTestRunnerViewSupport(ILaunchConfiguration launchConfiguration) {
+		try {
+			return getDefault()
+					.findTestViewSupport(launchConfiguration.getAttribute(
+							UnitTestLaunchConfigurationConstants.ATTR_UNIT_TEST_VIEW_SUPPORT, (String) null))
+					.orElse(null);
+		} catch (CoreException e) {
+			return null;
+		}
 	}
 
 	private List<IConfigurationElement> getConfigurationElements() {

--- a/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/model/TestCaseElement.java
+++ b/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/model/TestCaseElement.java
@@ -48,7 +48,6 @@ public class TestCaseElement extends TestElement implements ITestCaseElement {
 		return isIgnored() ? Result.IGNORED : super.getTestResult(includeChildren);
 	}
 
-	@Override
 	public void setIgnored(boolean ignored) {
 		fIgnored = ignored;
 	}

--- a/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/model/TestRunSession.java
+++ b/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/model/TestRunSession.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.eclipse.unittest.internal.UnitTestPlugin;
+import org.eclipse.unittest.internal.launcher.TestViewSupportRegistry;
 import org.eclipse.unittest.launcher.ITestRunnerClient;
 import org.eclipse.unittest.model.ITestCaseElement;
 import org.eclipse.unittest.model.ITestElement;
@@ -96,7 +97,7 @@ public class TestRunSession extends TestSuiteElement implements ITestRunSession,
 		// TODO: check assumptions about non-null fields
 
 		fLaunch = new NoopLaunch(launchConfiguration, ILaunchManager.RUN_MODE, null);
-		fTestRunnerSupport = UnitTestModel.newTestRunnerViewSupport(launchConfiguration);
+		fTestRunnerSupport = TestViewSupportRegistry.newTestRunnerViewSupport(launchConfiguration);
 
 		Assert.isNotNull(testRunName);
 		fTestRunName = testRunName;
@@ -123,7 +124,7 @@ public class TestRunSession extends TestSuiteElement implements ITestRunSession,
 		ILaunchConfiguration launchConfiguration = launch.getLaunchConfiguration();
 		if (launchConfiguration != null) {
 			fTestRunName = launchConfiguration.getName();
-			fTestRunnerSupport = UnitTestModel.newTestRunnerViewSupport(launchConfiguration);
+			fTestRunnerSupport = TestViewSupportRegistry.newTestRunnerViewSupport(launchConfiguration);
 		} else {
 			fTestRunName = "<TestRunSession>"; //$NON-NLS-1$
 			fTestRunnerSupport = null;

--- a/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/model/UnitTestLaunchListener.java
+++ b/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/model/UnitTestLaunchListener.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import org.eclipse.unittest.internal.UnitTestPlugin;
 import org.eclipse.unittest.internal.launcher.TestListenerRegistry;
 import org.eclipse.unittest.internal.launcher.TestRunListener;
+import org.eclipse.unittest.internal.launcher.TestViewSupportRegistry;
 import org.eclipse.unittest.internal.launcher.UnitTestLaunchConfigurationConstants;
 import org.eclipse.unittest.ui.ITestViewSupport;
 
@@ -55,7 +56,7 @@ public class UnitTestLaunchListener implements ILaunchListener {
 			return;
 		}
 
-		ITestViewSupport testRunnerViewSupport = UnitTestModel.newTestRunnerViewSupport(config);
+		ITestViewSupport testRunnerViewSupport = TestViewSupportRegistry.newTestRunnerViewSupport(config);
 		if (testRunnerViewSupport == null)
 			return;
 

--- a/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/model/UnitTestModel.java
+++ b/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/model/UnitTestModel.java
@@ -29,10 +29,7 @@ import org.xml.sax.SAXException;
 import org.eclipse.unittest.internal.UnitTestPlugin;
 import org.eclipse.unittest.internal.UnitTestPreferencesConstants;
 import org.eclipse.unittest.internal.junitXmlReport.TestRunHandler;
-import org.eclipse.unittest.internal.launcher.TestViewSupportRegistry;
-import org.eclipse.unittest.internal.launcher.UnitTestLaunchConfigurationConstants;
 import org.eclipse.unittest.model.ITestRunSession;
-import org.eclipse.unittest.ui.ITestViewSupport;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
@@ -41,8 +38,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Platform;
-
-import org.eclipse.debug.core.ILaunchConfiguration;
 
 /**
  * Central registry for Unit Test test runs.
@@ -289,19 +284,4 @@ public final class UnitTestModel {
 		}
 	}
 
-	/**
-	 * Returns {@link ITestViewSupport} instance from the given launch configuration
-	 *
-	 * @param launchConfiguration a launch configuration
-	 * @return a test runner view support instance if exists or <code>null</code>.
-	 */
-	public static ITestViewSupport newTestRunnerViewSupport(ILaunchConfiguration launchConfiguration) {
-		try {
-			return TestViewSupportRegistry.getDefault().getTestViewSupportInstance(launchConfiguration
-					.getAttribute(UnitTestLaunchConfigurationConstants.ATTR_UNIT_TEST_VIEW_SUPPORT, (String) null));
-		} catch (CoreException e) {
-			// Ignore
-		}
-		return null;
-	}
 }

--- a/org.eclipse.unittest.ui/src/org/eclipse/unittest/model/ITestCaseElement.java
+++ b/org.eclipse.unittest.ui/src/org/eclipse/unittest/model/ITestCaseElement.java
@@ -25,13 +25,6 @@ package org.eclipse.unittest.model;
 public interface ITestCaseElement extends ITestElement {
 
 	/**
-	 * Sets ignored flag on the test case
-	 *
-	 * @param ignored an ignored flag value
-	 */
-	void setIgnored(boolean ignored);
-
-	/**
 	 * Indicates if the test case was ignored
 	 *
 	 * @return true in case of the test case was ignored, otherwise false
@@ -44,5 +37,4 @@ public interface ITestCaseElement extends ITestElement {
 	 * @return true in case of dynamic test case element, otherwise false
 	 */
 	boolean isDynamicTest();
-
 }


### PR DESCRIPTION
…ew - Patch set #8

A set of fixes requested for Patch Set #8 at Gerrit Review: https://git.eclipse.org/r/c/platform/eclipse.platform.debug/+/171116

No nulls for progress monitor in TestRunHandler
findTestViewSupport() to return an Optional (ex- getTestViewSupportInstance())
newTestRunnerViewSupport() is moved from UnitTestModel to TestViewSupportRegistry
ITestCaseElement.setIgnored(boolean) is removed

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>