### PR TITLE
Bug 507626: Debug framework should provide a generic "test report" vi…

### DIFF
--- a/org.eclipse.unittest.cdt/src/org/eclipse/unittest/cdt/CDTUnitTestPlugin.java
+++ b/org.eclipse.unittest.cdt/src/org/eclipse/unittest/cdt/CDTUnitTestPlugin.java
@@ -19,7 +19,9 @@ package org.eclipse.unittest.cdt;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.preferences.InstanceScope;
@@ -121,4 +123,20 @@ public class CDTUnitTestPlugin extends Plugin {
 		return fBundleContext.getService(reference);
 	}
 
+	/**
+	 * Activates UnitTestBundle. Eclipse uses lazy bundle loading by default, which
+	 * means a bundle will not be loaded in many cases until some of its class is
+	 * used. This method allows the clients to instantiate the Unit Test bundle in
+	 * order to make it setup its launch listeners that are used to create and
+	 * activate Unit Test View. The Unit Test client bundles must call this method
+	 * before a Unit Test launch is created (preferably right before creation of the
+	 * launch in order to not make Eclipse to load the Unit Test bundle when it is
+	 * not really required), To load the Unit Test bundle the clients, for
+	 * example, might call this method inside their
+	 * 'ILaunchConfigurationDelegate2.getLaunch(ILaunchConfiguration, String)'
+	 * method of their launch configuration implementation.
+	 */
+	public static void activateUnitTestCoreBundle() {
+		Assert.isNotNull(Platform.getBundle("org.eclipse.unittest.ui")); //$NON-NLS-1$
+	}
 }

--- a/org.eclipse.unittest.cdt/src/org/eclipse/unittest/cdt/launcher/BaseTestsLaunchDelegate.java
+++ b/org.eclipse.unittest.cdt/src/org/eclipse/unittest/cdt/launcher/BaseTestsLaunchDelegate.java
@@ -26,8 +26,9 @@ import org.eclipse.cdt.testsrunner.internal.launcher.TestsRunnerProviderInfo;
 import org.eclipse.cdt.testsrunner.internal.ui.view.TestPathUtils;
 import org.eclipse.cdt.testsrunner.launcher.ITestsRunnerProvider;
 import org.eclipse.cdt.testsrunner.model.TestingException;
+import org.eclipse.unittest.cdt.CDTUnitTestPlugin;
 import org.eclipse.unittest.cdt.internal.launcher.LauncherMessages;
-import org.eclipse.unittest.ui.ITestViewSupport;
+import org.eclipse.unittest.ui.ConfigureViewerSupport;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -57,7 +58,7 @@ public abstract class BaseTestsLaunchDelegate extends LaunchConfigurationDelegat
 
 	@Override
 	public ILaunch getLaunch(ILaunchConfiguration config, String mode) throws CoreException {
-		ITestViewSupport.activateBundle();
+		CDTUnitTestPlugin.activateUnitTestCoreBundle();
 		return getPreferredDelegate(config, mode).getLaunch(config, mode);
 	}
 
@@ -145,7 +146,7 @@ public abstract class BaseTestsLaunchDelegate extends LaunchConfigurationDelegat
 	private void updatedLaunchConfiguration(ILaunchConfiguration config) throws CoreException {
 		changesToLaunchConfiguration.clear();
 		ILaunchConfigurationWorkingCopy configWC = config.getWorkingCopy();
-		ITestViewSupport.configure(configWC, getUnitTestViewSupportID());
+		new ConfigureViewerSupport(getUnitTestViewSupportID()).apply(configWC);
 		setProgramArguments(configWC);
 		configWC.doSave();
 	}

--- a/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/JUnitTestPlugin.java
+++ b/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/JUnitTestPlugin.java
@@ -25,6 +25,7 @@ import org.osgi.service.packageadmin.PackageAdmin;
 
 import org.eclipse.swt.widgets.Shell;
 
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
@@ -273,6 +274,23 @@ public class JUnitTestPlugin extends AbstractUIPlugin {
 		if (activeWorkbenchWindow == null)
 			return null;
 		return activeWorkbenchWindow.getActivePage();
+	}
+
+	/**
+	 * Activates UnitTestBundle. Eclipse uses lazy bundle loading by default, which
+	 * means a bundle will not be loaded in many cases until some of its class is
+	 * used. This method allows the clients to instantiate the Unit Test bundle in
+	 * order to make it setup its launch listeners that are used to create and
+	 * activate Unit Test View. The Unit Test client bundles must call this method
+	 * before a Unit Test launch is created (preferably right before creation of the
+	 * launch in order to not make Eclipse to load the Unit Test bundle when it is
+	 * not really required), To load the Unit Test bundle the clients, for example,
+	 * might call this method inside their
+	 * 'ILaunchConfigurationDelegate2.getLaunch(ILaunchConfiguration, String)'
+	 * method of their launch configuration implementation.
+	 */
+	public static void activateUnitTestCoreBundle() {
+		Assert.isNotNull(Platform.getBundle("org.eclipse.unittest.ui")); //$NON-NLS-1$
 	}
 
 }

--- a/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/launcher/JUnitLaunchConfigurationDelegate.java
+++ b/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/launcher/JUnitLaunchConfigurationDelegate.java
@@ -39,7 +39,6 @@ import org.osgi.framework.Constants;
 import org.eclipse.unittest.junit.JUnitMessages;
 import org.eclipse.unittest.junit.JUnitTestPlugin;
 import org.eclipse.unittest.junit.JUnitTestPlugin.JUnitVersion;
-import org.eclipse.unittest.ui.ITestViewSupport;
 
 import org.eclipse.core.variables.VariablesPlugin;
 
@@ -109,7 +108,7 @@ public class JUnitLaunchConfigurationDelegate extends AbstractJavaLaunchConfigur
 
 	@Override
 	public ILaunch getLaunch(ILaunchConfiguration configuration, String mode) throws CoreException {
-		ITestViewSupport.activateBundle();
+		JUnitTestPlugin.activateUnitTestCoreBundle();
 		return super.getLaunch(configuration, mode);
 	}
 

--- a/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/launcher/JUnitLaunchConfigurationTab.java
+++ b/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/launcher/JUnitLaunchConfigurationTab.java
@@ -29,7 +29,7 @@ import org.eclipse.unittest.junit.launcher.util.JUnitStubUtility;
 import org.eclipse.unittest.junit.launcher.util.LayoutUtil;
 import org.eclipse.unittest.junit.ui.BasicElementLabels;
 import org.eclipse.unittest.junit.ui.JUnitMessages;
-import org.eclipse.unittest.ui.ITestViewSupport;
+import org.eclipse.unittest.ui.ConfigureViewerSupport;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -559,7 +559,8 @@ public class JUnitLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
 			config.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_CONTAINER, ""); //$NON-NLS-1$
 			config.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_NAME, fTestMethodText.getText());
 		}
-		ITestViewSupport.configure(config, JUnitTestPlugin.UNIT_TEST_VIEW_SUPPORT_ID);
+
+		new ConfigureViewerSupport(JUnitTestPlugin.UNIT_TEST_VIEW_SUPPORT_ID).apply(config);
 		config.setAttribute(JUnitLaunchConfigurationConstants.ATTR_KEEPRUNNING, fKeepRunning.getSelection());
 		try {
 			mapResources(config);
@@ -1140,7 +1141,7 @@ public class JUnitLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
 		} catch (InterruptedException | InvocationTargetException ie) {
 		}
 		config.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, name);
-		ITestViewSupport.configure(config, testKindId);
+		new ConfigureViewerSupport(testKindId).apply(config);
 		initializeName(config, name);
 		boolean isRunWithJUnitPlatform = JUnitTestPlugin.isRunWithJUnitPlatform(javaElement);
 		if (isRunWithJUnitPlatform) {

--- a/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/launcher/JUnitLaunchShortcut.java
+++ b/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/launcher/JUnitLaunchShortcut.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
 import org.eclipse.unittest.junit.JUnitTestPlugin;
 import org.eclipse.unittest.junit.launcher.util.ExceptionHandler;
 import org.eclipse.unittest.junit.launcher.util.JUnitStubUtility;
-import org.eclipse.unittest.ui.ITestViewSupport;
+import org.eclipse.unittest.ui.ConfigureViewerSupport;
 
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
@@ -401,7 +401,7 @@ public class JUnitLaunchShortcut implements ILaunchShortcut2 {
 		wc.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_CONTAINER, containerHandleId);
 		wc.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_RUNNER_KIND,
 				JUnitTestPlugin.getJUnitVersion(element).getJUnitTestKind().getId());
-		ITestViewSupport.configure(wc, JUnitTestPlugin.UNIT_TEST_VIEW_SUPPORT_ID);
+		new ConfigureViewerSupport(JUnitTestPlugin.UNIT_TEST_VIEW_SUPPORT_ID).apply(wc);
 		JUnitMigrationDelegate.mapResources(wc);
 		AssertionVMArg.setArgDefault(wc);
 		if (testName != null) {

--- a/org.eclipse.unittest.ui/src/org/eclipse/unittest/ui/ConfigureViewerSupport.java
+++ b/org.eclipse.unittest.ui/src/org/eclipse/unittest/ui/ConfigureViewerSupport.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.unittest.ui;
+
+import java.util.function.Function;
+
+import org.eclipse.unittest.internal.launcher.UnitTestLaunchConfigurationConstants;
+
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+
+/**
+ * Configures a Launch configuration Working Copy with an identifier of Test
+ * View Support extension
+ */
+public final class ConfigureViewerSupport
+		implements Function<ILaunchConfigurationWorkingCopy, ILaunchConfigurationWorkingCopy> {
+	private final String identifier;
+
+	public ConfigureViewerSupport(String testViewSupportExtensionId) {
+		this.identifier = testViewSupportExtensionId;
+	}
+
+	@Override
+	public ILaunchConfigurationWorkingCopy apply(ILaunchConfigurationWorkingCopy configuration) {
+		if (configuration != null && identifier != null) {
+			configuration.setAttribute(UnitTestLaunchConfigurationConstants.ATTR_UNIT_TEST_VIEW_SUPPORT, identifier);
+		}
+		return configuration;
+	}
+}

--- a/org.eclipse.unittest.ui/src/org/eclipse/unittest/ui/ITestViewSupport.java
+++ b/org.eclipse.unittest.ui/src/org/eclipse/unittest/ui/ITestViewSupport.java
@@ -16,7 +16,6 @@ package org.eclipse.unittest.ui;
 import java.util.Collection;
 import java.util.List;
 
-import org.eclipse.unittest.internal.launcher.UnitTestLaunchConfigurationConstants;
 import org.eclipse.unittest.launcher.ITestRunnerClient;
 import org.eclipse.unittest.model.ITestCaseElement;
 import org.eclipse.unittest.model.ITestElement;
@@ -30,45 +29,12 @@ import org.eclipse.jface.action.IAction;
 import org.eclipse.ui.IViewPart;
 
 import org.eclipse.debug.core.ILaunchConfiguration;
-import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
-import org.eclipse.debug.core.model.ILaunchConfigurationDelegate2;
 
 /**
  * Interface to be implemented by a Test View Support to be returned by
  * org.org.eclipse.unittest.unittestViewSupport extension.
  */
 public interface ITestViewSupport {
-	/**
-	 * Activates UnitTestBundle. Eclipse uses lazy bundle loading by default, which
-	 * means a bundle will not be loaded in many cases until some of its class is
-	 * used. This method allows the clients to instantiate the Unit Test bundle in
-	 * order to make it setup its launch listeners that are used to create and
-	 * activate Unit Test View. The Unit Test client bundles must call this method
-	 * before a Unit Test launch is created (preferably right before creation of the
-	 * launch in order to not make Eclipse to load the Unit Test bundle when it is
-	 * not really required), To load the Unit Test bundle this the clients, for
-	 * example, might call this method inside
-	 * {@link ILaunchConfigurationDelegate2#getLaunch(ILaunchConfiguration, String)}
-	 * method of their launch configuration implementation.
-	 */
-	static void activateBundle() {
-		// Nothing more to do
-	}
-
-	/**
-	 * Configures a Launch configuration Working Copy with an identifier of Test
-	 * View Support extension
-	 *
-	 * @param configuration              a launch configuration working copy
-	 * @param testViewSupportExtensionId a Test View Support extension identifier
-	 */
-	static void configure(ILaunchConfigurationWorkingCopy configuration, String testViewSupportExtensionId) {
-		if (configuration != null && testViewSupportExtensionId != null) {
-			configuration.setAttribute(UnitTestLaunchConfigurationConstants.ATTR_UNIT_TEST_VIEW_SUPPORT,
-					testViewSupportExtensionId);
-		}
-	}
-
 	/**
 	 * Returns a Test Runner Client.
 	 *


### PR DESCRIPTION
…ew - Patch set #11

A set of fixes requested for Patch Set #11 at Gerrit Review: https://git.eclipse.org/r/c/platform/eclipse.platform.debug/+/171116

- ITestViewSupport.activateBundle() method is removed - since then the clients are to force activation of `org.eclipse.unittest.ui`
  bundle on their own

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>