### PR TITLE
Bug 507626: Debug framework should provide a generic "test report" vi…

### DIFF
--- a/org.eclipse.unittest.cdt/src/org/eclipse/unittest/cdt/launcher/CDTTestViewSupport.java
+++ b/org.eclipse.unittest.cdt/src/org/eclipse/unittest/cdt/launcher/CDTTestViewSupport.java
@@ -27,13 +27,13 @@ import org.eclipse.unittest.model.ITestRunSession;
 import org.eclipse.unittest.model.ITestSuiteElement;
 import org.eclipse.unittest.ui.ITestViewSupport;
 
+import org.eclipse.swt.widgets.Shell;
+
 import org.eclipse.core.text.StringMatcher;
 
 import org.eclipse.core.runtime.CoreException;
 
 import org.eclipse.jface.action.IAction;
-
-import org.eclipse.ui.IViewPart;
 
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
@@ -52,17 +52,17 @@ public class CDTTestViewSupport implements ITestViewSupport {
 	}
 
 	@Override
-	public IAction getOpenTestAction(IViewPart testRunnerPart, ITestCaseElement testCase) {
-		return new OpenTestAction(testRunnerPart, testCase.getParent(), testCase);
+	public IAction getOpenTestAction(Shell shell, ITestCaseElement testCase) {
+		return new OpenTestAction(shell, testCase.getParent(), testCase);
 	}
 
 	@Override
-	public IAction getOpenTestAction(IViewPart testRunnerPart, ITestSuiteElement testSuite) {
-		return new OpenTestAction(testRunnerPart, testSuite);
+	public IAction getOpenTestAction(Shell shell, ITestSuiteElement testSuite) {
+		return new OpenTestAction(shell, testSuite);
 	}
 
 	@Override
-	public IAction createOpenEditorAction(IViewPart testRunnerPart, ITestElement failure, String traceLine) {
+	public IAction createOpenEditorAction(Shell shell, ITestElement failure, String traceLine) {
 		try {
 			String testName= traceLine;
 			int indexOfFramePrefix= testName.indexOf(FRAME_PREFIX);
@@ -75,7 +75,7 @@ public class CDTTestViewSupport implements ITestViewSupport {
 			String lineNumber= traceLine;
 			lineNumber= lineNumber.substring(lineNumber.indexOf(':') + 1);
 			int line= Integer.parseInt(lineNumber);
-			return new OpenEditorAtLineAction(testRunnerPart, testName, failure.getTestRunSession(), line);
+			return new OpenEditorAtLineAction(shell, testName, failure.getTestRunSession(), line);
 		} catch(NumberFormatException | IndexOutOfBoundsException e) {
 			CDTUnitTestPlugin.log(e);
 		}

--- a/org.eclipse.unittest.cdt/src/org/eclipse/unittest/cdt/ui/OpenEditorAtLineAction.java
+++ b/org.eclipse.unittest.cdt/src/org/eclipse/unittest/cdt/ui/OpenEditorAtLineAction.java
@@ -20,6 +20,8 @@ import org.eclipse.cdt.debug.ui.CDebugUIPlugin;
 import org.eclipse.unittest.cdt.CDTUnitTestPlugin;
 import org.eclipse.unittest.model.ITestRunSession;
 
+import org.eclipse.swt.widgets.Shell;
+
 import org.eclipse.core.filesystem.URIUtil;
 
 import org.eclipse.core.runtime.CoreException;
@@ -37,7 +39,6 @@ import org.eclipse.jface.text.IRegion;
 
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
@@ -63,14 +64,14 @@ import org.eclipse.debug.ui.sourcelookup.ISourceLookupResult;
  * Opens the editor in place where the currently selected message is pointed to.
  */
 public class OpenEditorAtLineAction extends Action {
-	private IViewPart testRunner;
+	private Shell shell;
 	private String fileName;
 	private int line;
 	private ITestRunSession fTestRunSession;
 
-	public OpenEditorAtLineAction(IViewPart testRunner, String fileName, ITestRunSession testRunSession, int line) {
+	public OpenEditorAtLineAction(Shell shell, String fileName, ITestRunSession testRunSession, int line) {
 		super(ActionsMessages.OpenInEditorAction_text);
-		this.testRunner = testRunner;
+		this.shell = shell;
 		this.fileName = fileName;
 		this.fTestRunSession= testRunSession;
 		this.line = line;

--- a/org.eclipse.unittest.cdt/src/org/eclipse/unittest/cdt/ui/OpenTestAction.java
+++ b/org.eclipse.unittest.cdt/src/org/eclipse/unittest/cdt/ui/OpenTestAction.java
@@ -41,7 +41,6 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 
 import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.PartInitException;
 
 import org.eclipse.ui.texteditor.ITextEditor;
@@ -50,7 +49,7 @@ import org.eclipse.ui.texteditor.ITextEditor;
 public class OpenTestAction extends Action {
 	protected String fClassName;
 	protected String fMethodName;
-	protected IViewPart fTestRunner;
+	protected Shell shell;
 	private String fSearchPrefix;
 
 	/**
@@ -182,13 +181,13 @@ public class OpenTestAction extends Action {
 		}
 	}
 
-	public OpenTestAction(IViewPart testRunnerPart, ITestSuiteElement testSuite) {
-		this(testRunnerPart, testSuite, null);
+	public OpenTestAction(Shell shell, ITestSuiteElement testSuite) {
+		this(shell, testSuite, null);
 	}
 
-	public OpenTestAction(IViewPart testRunnerPart, ITestSuiteElement testSuite, ITestCaseElement testCase) {
+	public OpenTestAction(Shell shell, ITestSuiteElement testSuite, ITestCaseElement testCase) {
 		super(ActionsMessages.OpenEditorAction_action_label);
-		this.fTestRunner = testRunnerPart;
+		this.shell = shell;
 		this.fClassName = getClassName(testSuite);
 		this.fMethodName = testCase != null ? getTestMethodName(testCase) : "*"; //$NON-NLS-1$
 		this.fSearchPrefix = new StringBuilder(fClassName).append('_')
@@ -219,7 +218,7 @@ public class OpenTestAction extends Action {
 	}
 
 	protected Shell getShell() {
-		return fTestRunner.getSite().getShell();
+		return shell;
 	}
 
 	/**

--- a/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/ui/JUnitTestViewSupport.java
+++ b/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/ui/JUnitTestViewSupport.java
@@ -28,6 +28,7 @@ import org.eclipse.unittest.model.ITestSuiteElement;
 import org.eclipse.unittest.ui.ITestViewSupport;
 
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.core.text.StringMatcher;
 
@@ -36,8 +37,6 @@ import org.eclipse.core.runtime.Platform;
 
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.dialogs.MessageDialog;
-
-import org.eclipse.ui.IViewPart;
 
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -70,34 +69,34 @@ public class JUnitTestViewSupport implements ITestViewSupport {
 	}
 
 	@Override
-	public IAction getOpenTestAction(IViewPart testRunnerPart, ITestCaseElement testCase) {
-		return new OpenTestAction(testRunnerPart, testCase, getParameterTypes(testCase));
+	public IAction getOpenTestAction(Shell shell, ITestCaseElement testCase) {
+		return new OpenTestAction(shell, testCase, getParameterTypes(testCase));
 	}
 
 	@Override
-	public IAction getOpenTestAction(IViewPart testRunnerPart, ITestSuiteElement testSuite) {
+	public IAction getOpenTestAction(Shell shell, ITestSuiteElement testSuite) {
 		String testName = testSuite.getTestName();
 		List<? extends ITestElement> children = testSuite.getChildren();
 		if (testName.startsWith("[") && testName.endsWith("]") && !children.isEmpty() //$NON-NLS-1$ //$NON-NLS-2$
 				&& children.get(0) instanceof ITestCaseElement) {
 			// a group of parameterized tests
-			return new OpenTestAction(testRunnerPart, (ITestCaseElement) children.get(0), null);
+			return new OpenTestAction(shell, (ITestCaseElement) children.get(0), null);
 		}
 
 		int index = testName.indexOf('(');
 		// test factory method
 		if (index > 0) {
-			return new OpenTestAction(testRunnerPart, testSuite.getTestName(), testName.substring(0, index),
+			return new OpenTestAction(shell, testSuite.getTestName(), testName.substring(0, index),
 					getParameterTypes(testSuite), true, testSuite.getTestRunSession());
 		}
 
 		// regular test class
-		return new OpenTestAction(testRunnerPart, testName, testSuite.getTestRunSession());
+		return new OpenTestAction(shell, testName, testSuite.getTestRunSession());
 
 	}
 
 	@Override
-	public IAction createOpenEditorAction(IViewPart testRunnerPart, ITestElement failure, String traceLine) {
+	public IAction createOpenEditorAction(Shell shell, ITestElement failure, String traceLine) {
 		try {
 			String testName = traceLine;
 			int indexOfFramePrefix = testName.indexOf(FRAME_LINE_PREFIX);
@@ -118,7 +117,7 @@ public class JUnitTestViewSupport implements ITestViewSupport {
 			String lineNumber = traceLine;
 			lineNumber = lineNumber.substring(lineNumber.indexOf(':') + 1, lineNumber.lastIndexOf(')'));
 			int line = Integer.parseInt(lineNumber);
-			return new OpenEditorAtLineAction(testRunnerPart, testName, line, failure.getTestRunSession());
+			return new OpenEditorAtLineAction(shell, testName, line, failure.getTestRunSession());
 		} catch (NumberFormatException | IndexOutOfBoundsException e) {
 			JUnitTestPlugin.log(e);
 		}

--- a/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/ui/OpenEditorAction.java
+++ b/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/ui/OpenEditorAction.java
@@ -31,7 +31,6 @@ import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.dialogs.MessageDialog;
 
 import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.PlatformUI;
 
 import org.eclipse.ui.texteditor.ITextEditor;
@@ -55,20 +54,20 @@ import org.eclipse.jdt.ui.JavaUI;
  * Abstract Action for opening a Java editor.
  */
 public abstract class OpenEditorAction extends Action {
-	protected final IViewPart fTestRunner;
+	protected final Shell shell;
 	protected final ITestRunSession testSession;
 	protected String fClassName;
 	private final boolean fActivate;
 
-	protected OpenEditorAction(IViewPart testRunner, String testClassName, ITestRunSession session) {
-		this(testRunner, testClassName, true, session);
+	protected OpenEditorAction(Shell shell, String testClassName, ITestRunSession session) {
+		this(shell, testClassName, true, session);
 	}
 
-	public OpenEditorAction(IViewPart testRunner, String className, boolean activate, ITestRunSession session) {
+	public OpenEditorAction(Shell shell, String className, boolean activate, ITestRunSession session) {
 		super(JUnitMessages.OpenEditorAction_action_label);
-		fClassName = className;
-		fTestRunner = testRunner;
-		fActivate = activate;
+		this.fClassName = className;
+		this.shell = shell;
+		this.fActivate = activate;
 		this.testSession = session;
 	}
 
@@ -99,7 +98,7 @@ public abstract class OpenEditorAction extends Action {
 	}
 
 	protected Shell getShell() {
-		return fTestRunner.getSite().getShell();
+		return shell;
 	}
 
 	protected String getClassName() {

--- a/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/ui/OpenEditorAtLineAction.java
+++ b/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/ui/OpenEditorAtLineAction.java
@@ -17,12 +17,13 @@ package org.eclipse.unittest.junit.ui;
 
 import org.eclipse.unittest.model.ITestRunSession;
 
+import org.eclipse.swt.widgets.Shell;
+
 import org.eclipse.core.runtime.CoreException;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 
-import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.PlatformUI;
 
 import org.eclipse.ui.texteditor.ITextEditor;
@@ -37,8 +38,8 @@ public class OpenEditorAtLineAction extends OpenEditorAction {
 
 	private int fLineNumber;
 
-	public OpenEditorAtLineAction(IViewPart testRunner, String className, int line, ITestRunSession session) {
-		super(testRunner, className, session);
+	public OpenEditorAtLineAction(Shell shell, String className, int line, ITestRunSession session) {
+		super(shell, className, session);
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IJUnitHelpContextIds.OPENEDITORATLINE_ACTION);
 		fLineNumber = line;
 	}

--- a/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/ui/OpenTestAction.java
+++ b/org.eclipse.unittest.junit/src/org/eclipse/unittest/junit/ui/OpenTestAction.java
@@ -28,6 +28,8 @@ import org.eclipse.unittest.model.ITestCaseElement;
 import org.eclipse.unittest.model.ITestElement.FailureTrace;
 import org.eclipse.unittest.model.ITestRunSession;
 
+import org.eclipse.swt.widgets.Shell;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
@@ -37,7 +39,6 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 
-import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.PlatformUI;
 
 import org.eclipse.ui.texteditor.ITextEditor;
@@ -76,9 +77,9 @@ public class OpenTestAction extends OpenEditorAction {
 
 	private IType fType;
 
-	public OpenTestAction(IViewPart testRunnerPart, ITestCaseElement testCase, String[] methodParamTypes) {
-		this(testRunnerPart, JUnitTestViewSupport.getClassName(testCase), extractRealMethodName(testCase),
-				methodParamTypes, true, testCase.getTestRunSession());
+	public OpenTestAction(Shell shell, ITestCaseElement testCase, String[] methodParamTypes) {
+		this(shell, JUnitTestViewSupport.getClassName(testCase), extractRealMethodName(testCase), methodParamTypes,
+				true, testCase.getTestRunSession());
 		FailureTrace trace = testCase.getFailureTrace();
 		if (trace != null) {
 			String rawClassName = JUnitTestViewSupport.extractRawClassName(testCase.getTestName());
@@ -98,13 +99,13 @@ public class OpenTestAction extends OpenEditorAction {
 		}
 	}
 
-	public OpenTestAction(IViewPart testRunner, String className, ITestRunSession session) {
-		this(testRunner, className, null, null, true, session);
+	public OpenTestAction(Shell shell, String className, ITestRunSession session) {
+		this(shell, className, null, null, true, session);
 	}
 
-	public OpenTestAction(IViewPart testRunner, String className, String method, String[] methodParamTypes,
-			boolean activate, ITestRunSession session) {
-		super(testRunner, className, activate, session);
+	public OpenTestAction(Shell shell, String className, String method, String[] methodParamTypes, boolean activate,
+			ITestRunSession session) {
+		super(shell, className, activate, session);
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IJUnitHelpContextIds.OPENTEST_ACTION);
 		fMethodName = method;
 		fMethodParamTypes = methodParamTypes;

--- a/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/FailureTraceUIBlock.java
+++ b/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/FailureTraceUIBlock.java
@@ -142,8 +142,8 @@ public class FailureTraceUIBlock implements IMenuListener {
 	}
 
 	private IAction createOpenEditorAction(String traceLine) {
-		return fFailure.getTestRunSession().getTestViewSupport().createOpenEditorAction(fTestRunner, fFailure,
-				traceLine);
+		return fFailure.getTestRunSession().getTestViewSupport()
+				.createOpenEditorAction(fTestRunner.getSite().getShell(), fFailure, traceLine);
 	}
 
 	/**

--- a/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/TestViewer.java
+++ b/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/TestViewer.java
@@ -308,7 +308,7 @@ class TestViewer {
 			if (testElement instanceof TestSuiteElement) {
 				TestSuiteElement testSuiteElement = (TestSuiteElement) testElement;
 				IAction openTestAction = testSuiteElement.getTestRunSession().getTestViewSupport()
-						.getOpenTestAction(fTestRunnerPart, testSuiteElement);
+						.getOpenTestAction(fTestRunnerPart.getSite().getShell(), testSuiteElement);
 				if (openTestAction != null) {
 					manager.add(openTestAction);
 				}
@@ -319,7 +319,7 @@ class TestViewer {
 			} else {
 				TestCaseElement testCaseElement = (TestCaseElement) testElement;
 				IAction openTestAction = testElement.getTestRunSession().getTestViewSupport()
-						.getOpenTestAction(fTestRunnerPart, testCaseElement);
+						.getOpenTestAction(fTestRunnerPart.getSite().getShell(), testCaseElement);
 				if (openTestAction != null) {
 					manager.add(openTestAction);
 				}
@@ -392,11 +392,11 @@ class TestViewer {
 		TestElement testElement = (TestElement) selection.getFirstElement();
 		IAction action;
 		if (testElement instanceof ITestSuiteElement) {
-			action = testElement.getTestRunSession().getTestViewSupport().getOpenTestAction(fTestRunnerPart,
-					(ITestSuiteElement) testElement);
+			action = testElement.getTestRunSession().getTestViewSupport()
+					.getOpenTestAction(fTestRunnerPart.getSite().getShell(), (ITestSuiteElement) testElement);
 		} else if (testElement instanceof ITestCaseElement) {
-			action = testElement.getTestRunSession().getTestViewSupport().getOpenTestAction(fTestRunnerPart,
-					(ITestCaseElement) testElement);
+			action = testElement.getTestRunSession().getTestViewSupport()
+					.getOpenTestAction(fTestRunnerPart.getSite().getShell(), (ITestCaseElement) testElement);
 		} else {
 			throw new IllegalStateException(String.valueOf(testElement));
 		}

--- a/org.eclipse.unittest.ui/src/org/eclipse/unittest/ui/ITestViewSupport.java
+++ b/org.eclipse.unittest.ui/src/org/eclipse/unittest/ui/ITestViewSupport.java
@@ -22,11 +22,11 @@ import org.eclipse.unittest.model.ITestElement;
 import org.eclipse.unittest.model.ITestRunSession;
 import org.eclipse.unittest.model.ITestSuiteElement;
 
+import org.eclipse.swt.widgets.Shell;
+
 import org.eclipse.core.text.StringMatcher;
 
 import org.eclipse.jface.action.IAction;
-
-import org.eclipse.ui.IViewPart;
 
 import org.eclipse.debug.core.ILaunchConfiguration;
 
@@ -56,31 +56,31 @@ public interface ITestViewSupport {
 	/**
 	 * Returns an action to open a specified test elements
 	 *
-	 * @param testRunnerPart a test runner view part instance
-	 * @param testCase       a test case element
+	 * @param shell    a parent {@link Shell} instance
+	 * @param testCase a test case element
 	 * @return an action to open a specified test case element, or <code>null</code>
 	 */
-	IAction getOpenTestAction(IViewPart testRunnerPart, ITestCaseElement testCase);
+	IAction getOpenTestAction(Shell shell, ITestCaseElement testCase);
 
 	/**
 	 * Returns an action to open a specified test suite element
 	 *
-	 * @param testRunnerPart a test runner view part instance
-	 * @param testSuite      a test suite element
+	 * @param shell     a parent {@link Shell} instance
+	 * @param testSuite a test suite element
 	 * @return an action to open a specified test suite element, or
 	 *         <code>null</code>
 	 */
-	IAction getOpenTestAction(IViewPart testRunnerPart, ITestSuiteElement testSuite);
+	IAction getOpenTestAction(Shell shell, ITestSuiteElement testSuite);
 
 	/**
 	 * Returns an action to open a failure trace element
 	 *
-	 * @param testRunnerPart a test runner view part instance
-	 * @param failure        a test element that is failed
-	 * @param traceLine      a stack trace or an error message text
+	 * @param shell     a parent {@link Shell} instance
+	 * @param failure   a test element that is failed
+	 * @param traceLine a stack trace or an error message text
 	 * @return an action to open a failure trace element, or <code>null</null>
 	 */
-	IAction createOpenEditorAction(IViewPart testRunnerPart, ITestElement failure, String traceLine);
+	IAction createOpenEditorAction(Shell shell, ITestElement failure, String traceLine);
 
 	/**
 	 * Returns an action to copy an existing stack trace/error message into a


### PR DESCRIPTION
…ew - Patch set #12

A set of fixes requested for Patch Set #12 at Gerrit Review: https://git.eclipse.org/r/c/platform/eclipse.platform.debug/+/171116

IViewPart parameters are replaced with Shell in action get/create methods of ITestViewSupport

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>